### PR TITLE
Plot query bbox, not scenes. Add colors

### DIFF
--- a/notebooks/3.Gridded product development/3.1 Create ancillary raster stack - R CS, LD, SH (for no snow!), NT.ipynb
+++ b/notebooks/3.Gridded product development/3.1 Create ancillary raster stack - R CS, LD, SH (for no snow!), NT.ipynb
@@ -501,7 +501,8 @@
     }
    ],
    "source": [
-    "sc_bbox = scenes_poly.total_bounds\n",
+    "#sc_bbox = scenes_poly.total_bounds #scene boundaries is not as useful as the original bbox queried\n",
+    "sc_bbox = bbox_list[1]\n",
     "sc_bbox_polygon = shp.geometry.box(sc_bbox[0], sc_bbox[1], sc_bbox[2], sc_bbox[3])\n",
     "center = sc_bbox_polygon.centroid\n",
     "\n",
@@ -510,8 +511,12 @@
     "    tiles=\"cartodbpositron\",\n",
     "    zoom_start=6,\n",
     ")\n",
-    "folium.GeoJson(sc_bbox_polygon, name=\"bbox\").add_to(m)\n",
+    "bbox_style = {'fillColor': '#ff0000', 'color': '#ff0000'}\n",
+    "\n",
     "folium.GeoJson(scenes_poly, name=\"geojson\").add_to(m)\n",
+    "folium.GeoJson(sc_bbox_polygon,\n",
+    "               name=\"bbox\",\n",
+    "               style_function=lambda x:bbox_style).add_to(m)\n",
     "\n",
     "m"
    ]


### PR DESCRIPTION

![Screenshot from 2021-03-09 16-53-42](https://user-images.githubusercontent.com/306179/110558847-0dff1e00-80f8-11eb-9d8e-620b1713c3bf.png)
Nathan I found the bug in the plot where the bbox was always as big as the scenes, instead of a subset. Turns out it's because we weren't plotting the query box but rather a box made from the total of the scenes returned. Fixed, you can now see the box is smaller than the totals scenes.