### PR TITLE
Need to crop results, todo: warp/crop on read

### DIFF
--- a/notebooks/3.Gridded_product_development/3.1.2_dps.py
+++ b/notebooks/3.Gridded_product_development/3.1.2_dps.py
@@ -319,7 +319,16 @@ def main():
     out_file = os.path.join(outdir, 'Landsat8_' + str(tile_n) + '_comp_cog_2015-2020_dps.tif')
     
     # write COG to disk
-    write_cog(stack, out_file, in_crs, crs_transform, bandnames, out_crs=out_crs, resolution=(res, res))
+    write_cog(stack, 
+              out_file, 
+              in_crs, 
+              crs_transform, 
+              bandnames, 
+              out_crs=out_crs, 
+              resolution=(res, res), 
+              clip_geom = tile_id['geom_orig'],
+              clip_crs = out_crs,
+             )
 
 if __name__ == "__main__":
     '''


### PR DESCRIPTION
So the reprojection code is working in 3.1.2 however without cropping there's a lot of excessive data. This PR adds the cropping.

We should also open a new ticket to use WarpedVRT or rio-tiler, to read the data in as the end projection to start, and reduce the computation times 30-50% less pixels.