### PR TITLE
Remove duplicate scenes, pick latest processing date

### DIFF
--- a/notebooks/3.Gridded_product_development/fetch_from_api.py
+++ b/notebooks/3.Gridded_product_development/fetch_from_api.py
@@ -27,7 +27,13 @@ def write_local_data_and_catalog_s3(catalog, bands, save_path, local, s3_path="s
     with open(catalog) as f:
         clean_features = []
         asset_catalog = json.load(f)
-        for feature in asset_catalog['features']:
+        
+        # Remove duplicate scenes, keeping newest
+        features = asset_catalog['features']
+        sorted_features = sorted(features, key=lambda f: (f["properties"]["landsat:scene_id"], f["id"]))
+        most_recent_features = list({ f["properties"]["landsat:scene_id"]: f for f in sorted_features }.values())
+        
+        for feature in most_recent_features:
             #print(feature)
             try:
                 for band in bands:


### PR DESCRIPTION
@chuckwondo came up with a simple way to only keep the newest processing date when there are multiple records in USGS for the same SceneID.

This may make the need to check all urls for validity obsolete (but I think it's good to keep just in case).

Does not address that USGS recently added to their json a new property that has the s3 link already.
`['assets'][{bandname}]['alternate']['s3']['href']`
