### PR TITLE
use stacrs to query HLS STAC GeoParquet archive

### DIFF
--- a/dps/above_env_4.1.0.yml
+++ b/dps/above_env_4.1.0.yml
@@ -7,7 +7,7 @@ dependencies:
   #- pydantic<2
   - cachetools
   - h5netcdf
-  - stacrs==0.4.0
+  - stacrs==0.5.3
   #- rio-cogeo
   #- rio-tiler
   #- rio-cogeo==2.3.1

--- a/dps/above_env_4.1.0.yml
+++ b/dps/above_env_4.1.0.yml
@@ -7,6 +7,7 @@ dependencies:
   #- pydantic<2
   - cachetools
   - h5netcdf
+  - stacrs==0.4.0
   #- rio-cogeo
   #- rio-tiler
   #- rio-cogeo==2.3.1

--- a/dps/requirements_main.txt
+++ b/dps/requirements_main.txt
@@ -2,7 +2,7 @@
 #numpy==1.19.5
 h5py==3.1.0
 pandas==1.2.2
-stacrs==0.4.0
+stacrs==0.5.3
 #
 #alg_2-4
 pygeos==0.12.0

--- a/dps/requirements_main.txt
+++ b/dps/requirements_main.txt
@@ -2,6 +2,7 @@
 #numpy==1.19.5
 h5py==3.1.0
 pandas==1.2.2
+stacrs==0.4.0
 #
 #alg_2-4
 pygeos==0.12.0

--- a/lib/fetch_HLS.py
+++ b/lib/fetch_HLS.py
@@ -124,19 +124,19 @@ def query_stac(year, bbox, max_cloud, api, start_month_day, end_month_day, MS_pr
         results_list = []
         # Doing this loop to get around CMR bug: https://github.com/nasa/cmr-stac/pull/357
         # Loop can be removed and product list inserted back into 'collections' parameter when fixed
-        for MS_prod in MS_product_list:
-            
-            search = stacrs.search(
-                href=get_hls_geoparquet(),
-                collections=MS_prod,
-                datetime=f"{start}/{end}",
-                bbox = bbox,
-                limit=MAX_N_RESULTS,
-                max_items=None,
-                # query arg does not work with stacrs.search right now
-                # ,query={"eo:cloud_cover":{"lte":max_cloud}} # used to not work..now it does
-            )
-            results = search.get_all_items_as_dict()
+        for MS_prod in MS_product_list: 
+            results = {
+                "features": stacrs.search(
+                    href=get_hls_geoparquet(),
+                    collections=MS_prod,
+                    datetime=f"{start}/{end}",
+                    bbox = bbox,
+                    limit=MAX_N_RESULTS,
+                    max_items=None,
+                    # query arg does not work with stacrs.search right now
+                    # ,query={"eo:cloud_cover":{"lte":max_cloud}} # used to not work..now it does
+                )
+            }
             print(f"partial results ({MS_prod}):\t\t\t\t{len(results['features'])}")
             results_list.append(results)
 


### PR DESCRIPTION
I built this [tool](https://github.com/developmentseed/stac_cache/tree/hr/third-attempt) for dumping large STAC queries into a GeoParquet file (which [`stacrs`](https://github.com/gadomski/stacrs) can read). This makes it possible to do STAC queries for HLS data without hitting the CMR STAC API which has recently introduced some rate limits that make these types of batch jobs difficult.